### PR TITLE
Updated redirects to be more intuitive

### DIFF
--- a/src/components/Back/Back.astro
+++ b/src/components/Back/Back.astro
@@ -20,6 +20,7 @@ import "./Back.scss";
         window.history.back();
       }
     }
+    // @ts-ignore
     window.handleBackClick = handleBackClick;
   });
 </script>

--- a/src/components/Back/Back.astro
+++ b/src/components/Back/Back.astro
@@ -1,8 +1,25 @@
 ---
-const { href, label } = Astro.props;
+const { href = "", label = "Back" } = Astro.props;
 import "./Back.scss";
 ---
 
-<a class="Back" href={href}
-  ><i class="mdi mdi-keyboard-backspace"></i> {label}</a
->
+<div class="Back" onclick={`handleBackClick('${href}')`}>
+  <i class="mdi mdi-keyboard-backspace"></i>
+  {label}
+</div>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    function handleBackClick(href: string) {
+      const isSameOrigin = document.referrer.includes(window.origin);
+      if (!isSameOrigin) {
+        window.location.href = "/";
+      } else if (href !== "") {
+        window.location.href = href;
+      } else {
+        window.history.back();
+      }
+    }
+    window.handleBackClick = handleBackClick;
+  });
+</script>

--- a/src/pages/practice/tag/[tag].astro
+++ b/src/pages/practice/tag/[tag].astro
@@ -112,7 +112,7 @@ const tabTitle = tag
 <Layout title={tabTitle}>
   <div class="Question__bar">
     <div>
-      <Back href={`/questions/${randomQuestion.data.path}`} label="Back" />
+      <Back />
     </div>
   </div>
 

--- a/src/pages/questions/[...path].astro
+++ b/src/pages/questions/[...path].astro
@@ -52,7 +52,7 @@ const title = formatString(path);
 
 <Layout title={title + " Question"}>
   <div class="Question__bar">
-    <div><Back href={`/evaluations`} label="Evaluations" /></div>
+    <div><Back /></div>
   </div>
   <h1>{title}</h1>
   <Content />

--- a/src/pages/questions/solution/[...path].astro
+++ b/src/pages/questions/solution/[...path].astro
@@ -44,7 +44,7 @@ const question = await loadQuestion();
 
 <Layout title="Solution">
   <div class="Question__bar">
-    <div><Back href={`/questions/${path}`} label="Back" /></div>
+    <div><Back /></div>
   </div>
   <Content />
   <div>


### PR DESCRIPTION
Fixes #9

Instead of relabeling and hardcoding, it works off the following logic:
- if previous page url has same root as our website...
  - if no href was passed down, take to wherever they were before since they were on our website
  - if an explicit href was passed down, take client to wherever the href is since it's still on our website
- if came from foreign page, take to home page