### PR TITLE
Add Lectures page with YAML-based content loading [#41]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "astro": "^4.11.1",
         "axios": "^1.7.7",
         "fs": "^0.0.1-security",
+        "js-yaml": "^4.1.0",
         "katex": "^0.16.10",
         "mathjax": "^3.2.2",
         "mathjax-full": "^3.2.2",
@@ -7424,6 +7425,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "astro": "^4.11.1",
     "axios": "^1.7.7",
     "fs": "^0.0.1-security",
+    "js-yaml": "^4.1.0",
     "katex": "^0.16.10",
     "mathjax": "^3.2.2",
     "mathjax-full": "^3.2.2",

--- a/src/components/Sidebar/Sidebar.astro
+++ b/src/components/Sidebar/Sidebar.astro
@@ -28,7 +28,7 @@ const sections = [
     icon: "mdi mdi-video",
     title: "Lectures",
     disabled: false,
-    link: "https://www.youtube.com/playlist?list=PLY7TEz3ZRQHTnY56q2uJtdXg-bl-c0sDk",
+    link: "/lectures",
   },
   { icon: "mdi mdi-creation", title: "Sandbox", disabled: true },
   // { icon: "mdi mdi-beaker", title: "Experiments", disabled: true },

--- a/src/components/Sidebar/Sidebar.astro
+++ b/src/components/Sidebar/Sidebar.astro
@@ -28,6 +28,7 @@ const sections = [
     icon: "mdi mdi-video",
     title: "Lectures",
     disabled: false,
+    // link: "https://www.youtube.com/playlist?list=PLY7TEz3ZRQHTnY56q2uJtdXg-bl-c0sDk",
     link: "/lectures",
   },
   { icon: "mdi mdi-creation", title: "Sandbox", disabled: true },

--- a/src/data/lectures.yml
+++ b/src/data/lectures.yml
@@ -1,0 +1,7 @@
+- course: COMP 2804
+  title: Fall 2020 Lecture
+  link: https://www.youtube.com/playlist?list=PLY7TEz3ZRQHTnY56q2uJtdXg-bl-c0sDk
+
+- course: COMP 2804
+  title: KPOP Demon Hunters Playlist
+  link: https://www.youtube.com/playlist?list=PLxA687tYuMWhg-QcZRiO2eCzkQNN1rEBI

--- a/src/data/lectures.yml
+++ b/src/data/lectures.yml
@@ -1,7 +1,3 @@
 - course: COMP 2804
   title: Fall 2020 Lecture
   link: https://www.youtube.com/playlist?list=PLY7TEz3ZRQHTnY56q2uJtdXg-bl-c0sDk
-
-- course: COMP 2804
-  title: KPOP Demon Hunters Playlist
-  link: https://www.youtube.com/playlist?list=PLxA687tYuMWhg-QcZRiO2eCzkQNN1rEBI

--- a/src/pages/lectures.astro
+++ b/src/pages/lectures.astro
@@ -32,15 +32,13 @@ for (const lec of lectures) {
       <>
         <h2>{course}</h2>
         <div class="Items">
-          {
-            list.map((lec) => (
-              <a href={lec.link} target="_blank">
-                <RowCard title={lec.title} icon="mdi mdi-video" />
-              </a>
-            ))
-          }
+          {list.map((lec) => (
+            <a href={lec.link} target="_blank">
+              <RowCard title={lec.title} icon="mdi mdi-video" />
+            </a>
+          ))}
         </div>
-        <div style="margin-top:2.5rem"></div>
+        <div style="margin-top:2.5rem" />
       </>
     ))
   }

--- a/src/pages/lectures.astro
+++ b/src/pages/lectures.astro
@@ -1,13 +1,59 @@
 ---
 import Back from "@components/Back/Back.astro";
 import { default as Layout } from "src/layouts/Content/Content.astro";
+import RowCard from "@components/RowCard/RowCard.astro";
+import fs from "fs";
+import path from "path";
+import yaml from "js-yaml";
+
+const filePath = path.resolve("src/data/lectures.yml");
+const file = fs.readFileSync(filePath, "utf8");
+const lectures = yaml.load(file);
+
+const grouped = {};
+for (const lec of lectures) {
+  if (!grouped[lec.course]) grouped[lec.course] = [];
+  grouped[lec.course].push(lec);
+}
 ---
 
 <Layout title="Lectures">
   <div class="Question__bar">
-    <Back href={`/`} label="Home" />
+    <Back href="/" label="Home" />
   </div>
 
   <h1>📚 Lectures</h1>
-  <p>This is a placeholder page for archived lectures. YAML integration coming soon.</p>
+  <p>Playlists of recorded lecture videos categorized by course.</p>
+
+  <div style="margin-top:2.5rem"></div>
+
+  {
+    Object.entries(grouped).map(([course, list]) => (
+      <>
+        <h2>{course}</h2>
+        <div class="Items">
+          {
+            list.map((lec) => (
+              <a href={lec.link} target="_blank">
+                <RowCard title={lec.title} icon="mdi mdi-video" />
+              </a>
+            ))
+          }
+        </div>
+        <div style="margin-top:2.5rem"></div>
+      </>
+    ))
+  }
 </Layout>
+
+<style>
+  p {
+    color: gray;
+  }
+
+  .Items {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+</style>

--- a/src/pages/lectures.astro
+++ b/src/pages/lectures.astro
@@ -1,0 +1,13 @@
+---
+import Back from "@components/Back/Back.astro";
+import { default as Layout } from "src/layouts/Content/Content.astro";
+---
+
+<Layout title="Lectures">
+  <div class="Question__bar">
+    <Back href={`/`} label="Home" />
+  </div>
+
+  <h1>📚 Lectures</h1>
+  <p>This is a placeholder page for archived lectures. YAML integration coming soon.</p>
+</Layout>


### PR DESCRIPTION

### 📝 Description:

* Created `lectures.yml` in `src/data` to store lecture metadata.
* Implemented YAML parsing using `js-yaml` and Node's `fs` module.
* Rendered lecture playlists grouped by course on the `/lectures` page.
* Styled the page to match the rest of the app (e.g., `practice-by-tag` layout).
* Added two sample playlists for `COMP 2804`, including:

  * **Fall 2020 Lecture**
  * **KPOP Demon Hunters** (placeholder until more actual content is available)
* New lectures can be added by editing the YAML file without modifying component code.
Closes #41
